### PR TITLE
Use packer ^0.0.6 for jsdom >4.0.0 & NodeJS issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "event-stream": "^3.1.5",
     "gulp-util": "^2.2.16",
-    "packer": "0.0.5"
+    "packer": "^0.0.6"
   },
   "devDependencies": {
     "nodeunit": "^0.9.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-packer",
   "description": "Minify Javascript",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "http://github.com/yanatan16/gulp-packer",
   "repository": "git://github.com/yanatan16/gulp-packer.git",
   "author": "Jon Eisen <jon@joneisen.me> (http://joneisen.me/)",


### PR DESCRIPTION
Packer 0.0.5 installs jsdom >4.0.0 as a dependency, which doesn't work with NodeJS anymore (https://github.com/tmpvar/jsdom/issues/1047)

This is fixed since Packer 0.0.6 (https://github.com/evanw/packer/pull/4), so we want to use at least that version for gulp-packer.
